### PR TITLE
add domain list length condition

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -163,6 +163,7 @@ async function replaceImgUrl(progress) {
     if (
       domainList !== undefined &&
       domainList !== null &&
+      domainList.length > 0 &&
       domainList.includes(new URL(imageUrl).hostname)
     ) {
       console.log(`图片 ${imageUrl} 在 domainList 中，跳过`);


### PR DESCRIPTION
when `domainList` is not config, still you can get `domainList` objects with `[]`, when `imageUrl` maybe local image location, so `new URL()` will throw an error
- solution 1: add domain list length conditions for empty array; 